### PR TITLE
Fix calculation of STIX pointing in HPC to imaging demo

### DIFF
--- a/changelog/112.doc.rst
+++ b/changelog/112.doc.rst
@@ -1,0 +1,1 @@
+Correct calculation of the HPC coordinate of the center of the STIX pointing in the imaging demo.

--- a/examples/imaging_demo.py
+++ b/examples/imaging_demo.py
@@ -129,7 +129,7 @@ coord = STIXImaging(0*u.arcsec, 0*u.arcsec, obstime='2021-09-23T15:22:30', obser
 header = make_fitswcs_header(bp_image, coord, telescope='STIX', observatory='Solar Orbiter', scale=[10,10]*u.arcsec/u.pix)
 fd_bp_map = Map((bp_image, header))
 
-hpc_ref = Helioprojective(pointing[0], pointing[1], observer=solo, obstime=fd_bp_map.date)
+hpc_ref = coord.transform_to(Helioprojective(observer=solo, obstime=fd_bp_map.date))  # Center of STIX pointing in HPC
 header_hp = make_fitswcs_header(bp_image, hpc_ref, scale=[10, 10]*u.arcsec/u.pix, rotation_angle=90*u.deg+roll)
 hp_map = Map((bp_image, header_hp))
 hp_map_rotated = hp_map.rotate()


### PR DESCRIPTION
This PR corrects how the HPC coordinate of the centre of the STIX pointing is calculated in the imaging demo.  While the pre-existing calculation is approximately valid in the demo's case, it is not valid for substanital roll angle.  The approach given in the PR should be valid for all roll angles.