### PR TITLE
Bugifx ql timeseries units

### DIFF
--- a/changelog/118.bugfix.rst
+++ b/changelog/118.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where the incorrect unit was set on :class:`~stixpy.timeseries.quicklook.QLLightCurve`, :class:`~stixpy.timeseries.quicklook.QLBackground` and :class:`~stixpy.timeseries.quicklook.QLVariance`.

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -596,8 +596,8 @@ class HKMaxi(GenericTimeSeries):
             The path to the file you want to parse.
         """
         header = hdulist[0].header
-        control = _hdu_to_qtable(hdulist[1])
-        header["control"] = control
+        # control = _hdu_to_qtable(hdulist[1])
+        # header["control"] = control
         data = _hdu_to_qtable(hdulist[2])
 
         try:

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -49,7 +49,7 @@ class QLLightCurve(GenericTimeSeries):
 
     _source = "stix"
 
-    def plot(self, axes=None, columns='counts', **plot_args):
+    def plot(self, axes=None, columns=None, **plot_args):
         r"""
         Show a plot of the data.
 
@@ -58,6 +58,8 @@ class QLLightCurve(GenericTimeSeries):
         axes : `~matplotlib.axes.Axes`, optional
             If provided the image will be plotted on the given axes.
             Defaults to `None`, so the current axes will be used.
+        columns : `list`, optional
+            Columns to plot, defaults to 'counts'.
         **plot_args : `dict`, optional
             Additional plot keyword arguments that are handed to
             :meth:`pandas.DataFrame.plot`.
@@ -67,7 +69,7 @@ class QLLightCurve(GenericTimeSeries):
         axes : `~matplotlib.axes.Axes`
             The plot axes.
         """
-        if columns == 'counts':
+        if columns is None:
             count_re = re.compile(r"\d+-\d+ keV$")
             columns = [column for column in self.columns if count_re.match(column)]
 
@@ -216,7 +218,7 @@ class QLBackground(GenericTimeSeries):
 
     """
 
-    def plot(self, axes=None, columns='counts', **plot_args):
+    def plot(self, axes=None, columns=None, **plot_args):
         r"""
         Show a plot of the data.
 
@@ -226,7 +228,7 @@ class QLBackground(GenericTimeSeries):
             If provided the image will be plotted on the given axes.
             Defaults to `None`, so the current axes will be used.
         columns : `str`, optional
-            Columns to plot. Defaults to 'counts'.
+            Columns to plot, defaults to 'counts'.
         **plot_args : `dict`, optional
             Additional plot keyword arguments that are handed to
             :meth:`pandas.DataFrame.plot`.
@@ -381,15 +383,18 @@ class QLVariance(GenericTimeSeries):
     [21516 rows x 4 columns]
     """
 
-    def plot(self, axes=None, columns='variance', **plot_args):
+    def plot(self, axes=None, columns=None, **plot_args):
         """
         Show a plot of the data.
 
         Parameters
         ----------
+
         axes : `~matplotlib.axes.Axes`, optional
             If provided the image will be plotted on the given axes.
             Defaults to `None`, so the current axes will be used.
+        columns :
+            Columns to plot, defaults to 'variance'.
         **plot_args : `dict`, optional
             Additional plot keyword arguments that are handed to
             :meth:`pandas.DataFrame.plot`.
@@ -399,7 +404,7 @@ class QLVariance(GenericTimeSeries):
         axes : `~matplotlib.axes.Axes`
             The plot axes.
         """
-        if columns == 'variance':
+        if columns is None:
             count_re = re.compile(r"\d+-\d+ keV$")
             columns = [column for column in self.columns if count_re.match(column)]
 

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -41,7 +41,7 @@ class QLLightCurve(GenericTimeSeries):
     r"""
     Quicklook X-ray time series.
 
-    Nominally in five energy bands from 4-150 keV which are obtained by summing counts for all masked detectors and
+    Nominally the quicklook data files contain the STIX timeseries data in five energy bands from 4-150 keV which are obtained by summing counts for all masked detectors and
     pixels into five predefined energy ranges. They are double buffered with default integration time of 4s and depth
     of 32 bits. Maximum rate is approximately 1MHz with one summed live time counter for the appropriate detectors.
 
@@ -111,7 +111,7 @@ class QLLightCurve(GenericTimeSeries):
     @classmethod
     def _parse_file(cls, filepath):
         r"""
-        Parses a STIX file.
+        Parses a STIX QL file.
 
         Parameters
         ----------

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -28,7 +28,7 @@ def _hdu_to_qtable(hdupair):
     QTable
     """
     header = hdupair.header
-    # TODD remove when python 3.9 and astropy 5.3.4 are dropped weird non-ascii error
+    # TODO remove when python 3.9 and astropy 5.3.4 are dropped weird non-ascii error
     header.pop('keycomments')
     header.pop('comment')
     bintable = BinTableHDU(hdupair.data, header=Header(cards=header))

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -83,9 +83,10 @@ class QLLightCurve(GenericTimeSeries):
             # label to the y-axis.
             unit = u.Unit(list(units)[0])
             axes.set_ylabel(unit.to_string())
+            if unit == u.ct/(u.s * u.keV):
+                axes.set_yscale("log")
 
         axes.set_title("STIX QL Light Curve")
-        axes.set_yscale("log")
         axes.legend()
         self._setup_x_axis(axes)
         return axes
@@ -119,7 +120,7 @@ class QLLightCurve(GenericTimeSeries):
         energies = QTable(hdulist[4].data)
         energy_delta = energies["e_high"] - energies["e_low"] << u.keV
 
-        live_time = _lfrac(data["triggers"].reshape(-1) / (16 * data["timedel"] * u.s))
+        live_time = _lfrac(data["triggers"].reshape(-1) / (16 * data["timedel"] * u.cs))
 
         data["counts"] = data["counts"] / (live_time.reshape(-1, 1) * energy_delta)
 
@@ -139,7 +140,7 @@ class QLLightCurve(GenericTimeSeries):
             data["time"] = Time(header["date-obs"]) + TimeDelta(data["time"] * u.cs)
 
         units = OrderedDict(
-            [("control_index", None), ("timedel", u.s), ("triggers", None), ("triggers_comp_err", None), ("rcr", None)]
+            [("control_index", None), ("timedel", u.cs), ("triggers", None), ("triggers_comp_err", None), ("rcr", None)]
         )
         units.update([(name, u.ct / (u.s * u.keV)) for name in names])
         units.update([(f"{name}_comp_err", u.ct/(u.s * u.keV)) for name in names])
@@ -308,7 +309,7 @@ class QLBackground(GenericTimeSeries):
             data["time"] = Time(header["date-obs"]) + TimeDelta(data["time"] * u.s)
 
         units = OrderedDict(
-            [("control_index", None), ("timedel", u.s), ("triggers", None), ("triggers_comp_err", None), ("rcr", None)]
+            [("control_index", None), ("timedel", u.cs), ("triggers", None), ("triggers_comp_err", None), ("rcr", None)]
         )
         units.update([(name, u.ct/(u.s * u.keV)) for name in names])
         units.update([(f"{name}_comp_err", u.ct/(u.s * u.keV)) for name in names])
@@ -473,7 +474,7 @@ class QLVariance(GenericTimeSeries):
         data.add_column(data["variance_comp_err"], name=f"{name}_comp_err")
         data.remove_column("variance_comp_err")
 
-        units = OrderedDict([("control_index", None), ("timedel", u.s),
+        units = OrderedDict([("control_index", None), ("timedel", u.cs),
                              (name, u.ct/(u.s * u.keV)), (f"{name}_comp_err", u.ct/(u.s * u.keV))])
 
         data[name] = data[name].reshape(-1)
@@ -596,9 +597,9 @@ class HKMaxi(GenericTimeSeries):
         data = Table(hdulist[2].data)
 
         try:
-            data["time"] = Time(header["date_obs"]) + TimeDelta(data["time"] * u.s)
+            data["time"] = Time(header["date_obs"]) + TimeDelta(data["time"] * u.cs)
         except KeyError:
-            data["time"] = Time(header["date-obs"]) + TimeDelta(data["time"] * u.s)
+            data["time"] = Time(header["date-obs"]) + TimeDelta(data["time"] * u.cs)
 
         data_df = data.to_pandas()
         data_df.index = data_df["time"]

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -7,7 +7,6 @@ from astropy.io import fits
 from astropy.table import QTable, Table
 from astropy.time.core import Time, TimeDelta
 from sunpy.timeseries.timeseriesbase import GenericTimeSeries
-from sunpy.visualization import peek_show
 
 __all__ = ["QLLightCurve", "QLBackground", "QLVariance", "HKMaxi"]
 
@@ -50,23 +49,6 @@ class QLLightCurve(GenericTimeSeries):
 
     _source = "stix"
 
-    @peek_show
-    def peek(self, **kwargs):
-        r"""
-        Displays a graphical overview of the data in this object for user evaluation.
-        For the creation of plots, users should instead use the
-        `.plot` method and Matplotlib's pyplot framework.
-
-        Parameters
-        ----------
-        **kwargs : `dict`
-            Any additional plot arguments that should be used when plotting.
-        """
-
-        # Check we have a timeseries valid for plotting
-        self._validate_data_for_plotting()
-        self.plot(**kwargs)
-
     def plot(self, axes=None, columns='counts', **plot_args):
         r"""
         Show a plot of the data.
@@ -94,7 +76,7 @@ class QLLightCurve(GenericTimeSeries):
         axes = self._data[columns].plot(ax=axes, **plot_args)
 
         units = set([self.units[col] for col in columns])
-        if len(units) == 1:
+        if len(units) == 1 and list(units)[0] is not None:
             # If units of all columns being plotted are the same, add a unit
             # label to the y-axis.
             unit = u.Unit(list(units)[0])
@@ -234,23 +216,6 @@ class QLBackground(GenericTimeSeries):
 
     """
 
-    @peek_show
-    def peek(self, **kwargs):
-        r"""
-        Displays a graphical overview of the data in this object for user evaluation.
-        For the creation of plots, users should instead use the
-        `.plot` method and Matplotlib's pyplot framework.
-
-        Parameters
-        ----------
-        **kwargs : `dict`
-            Any additional plot arguments that should be used when plotting.
-        """
-
-        # Check we have a timeseries valid for plotting
-        self._validate_data_for_plotting()
-        self.plot(**kwargs)
-
     def plot(self, axes=None, columns='counts', **plot_args):
         r"""
         Show a plot of the data.
@@ -280,7 +245,7 @@ class QLBackground(GenericTimeSeries):
         axes = self._data[columns].plot(ax=axes, **plot_args)
 
         units = set([self.units[col] for col in columns])
-        if len(units) == 1:
+        if len(units) == 1 and list(units)[0] is not None:
             # If units of all columns being plotted are the same, add a unit
             # label to the y-axis.
             unit = u.Unit(list(units)[0])
@@ -439,11 +404,10 @@ class QLVariance(GenericTimeSeries):
             columns = [column for column in self.columns if count_re.match(column)]
 
         axes, columns = self._setup_axes_columns(axes, columns)
-
         axes = self._data[columns].plot(ax=axes, **plot_args)
 
         units = set([self.units[col] for col in columns])
-        if len(units) == 1:
+        if len(units) == 1 and list(units)[0] is not None:
             # If units of all columns being plotted are the same, add a unit
             # label to the y-axis.
             unit = u.Unit(list(units)[0])

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -178,7 +178,7 @@ class QLBackground(GenericTimeSeries):
 
     Background monitoring is done in such way that counts from background detector are summed in five specified energy
     ranges. These QL data are double buffered into accumulators of 32bit depth. Maximum rate is approximately 30kHz and
-     one live time counter is available. Integration time is parameter with default value of 32s
+    one live time counter is available. Integration time is parameter with default value of 32s
 
     Examples
     --------

--- a/stixpy/timeseries/quicklook.py
+++ b/stixpy/timeseries/quicklook.py
@@ -31,7 +31,9 @@ def _hdu_to_qtable(hdupair):
 
     """
     header = hdupair.header
-    header.pop('KEYCOMMENTS')
+    # TODD remove when python 3.9 and astropy 5.3.4 dropped
+    header.pop('keycomments')
+    header.pop('comment')
     bintable = BinTableHDU(hdupair.data, header=Header(cards=header))
     table = read_table_fits(bintable)
     qtable = QTable(table)

--- a/stixpy/timeseries/tests/test_quicklook.py
+++ b/stixpy/timeseries/tests/test_quicklook.py
@@ -13,6 +13,7 @@ def ql_lightcurve():
     )
     return ql_lc
 
+
 @pytest.mark.remote_data
 @pytest.fixture()
 def ql_background():
@@ -20,6 +21,7 @@ def ql_background():
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-background_20200506_V02.fits"
     )
     return ql_bkg
+
 
 @pytest.mark.remote_data
 @pytest.fixture()
@@ -29,10 +31,21 @@ def ql_variance():
     )
     return ql_var
 
+
+@pytest.mark.remote_data
+@pytest.fixture()
+def hk_maxi():
+    hk_maxi = TimeSeries(
+        r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/HK/solo_L1_stix-hk-maxi_20200506_V02U.fits"
+    )
+    return hk_maxi
+
+
 @pytest.mark.remote_data
 def test_ql_lightcurve(ql_lightcurve):
     assert isinstance(ql_lightcurve, QLLightCurve)
     assert ql_lightcurve.quantity('4-10 keV').unit == u.ct/(u.s * u.keV)
+
 
 @pytest.mark.remote_data
 def test_ql_lightcurve_plot(ql_lightcurve):
@@ -52,23 +65,25 @@ def test_ql_background_plot(ql_background):
     ql_background.plot(columns=['4-10 keV'])
 
 
-
 @pytest.mark.remote_data
-def test_qlvariance(ql_variance):
+def test_ql_variance(ql_variance):
     assert isinstance(ql_variance, QLVariance)
     assert ql_variance.quantity('4-20 keV').unit == u.ct / (u.s * u.keV)
 
 
 @pytest.mark.remote_data
-def test_qlvariance_plot(ql_variance):
+def test_ql_variance_plot(ql_variance):
     ql_variance.plot()
     ql_variance.plot(columns=['4-20 keV'])
 
 
+@pytest.mark.remote_data
+def test_hk_maxi(hk_maxi):
+    assert isinstance(hk_maxi, HKMaxi)
+    assert hk_maxi.quantity('hk_att_c').unit == u.mA
+
 
 @pytest.mark.remote_data
-def test_hk_maxi():
-    hk_maxi = TimeSeries(
-        "https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/HK/solo_L1_stix-hk-maxi_20200506_V02U.fits"
-    )
-    assert isinstance(hk_maxi, HKMaxi)
+def test_hk_maxi_plot(hk_maxi):
+    hk_maxi.plot()
+    hk_maxi.plot(columns=['hk_asp_photoa0_v'])

--- a/stixpy/timeseries/tests/test_quicklook.py
+++ b/stixpy/timeseries/tests/test_quicklook.py
@@ -1,3 +1,4 @@
+import astropy.units as u
 import pytest
 from sunpy.timeseries import TimeSeries
 
@@ -10,22 +11,25 @@ def test_ql_lightcurve():
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-lightcurve_20200506_V02.fits"
     )
     assert isinstance(ql_lc, QLLightCurve)
+    assert ql_lc.quantity('4-10 keV').unit == u.ct/(u.s * u.keV)
 
 
 @pytest.mark.remote_data
 def test_qlbackground():
-    ql_lc = TimeSeries(
+    ql_bkg = TimeSeries(
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-background_20200506_V02.fits"
     )
-    assert isinstance(ql_lc, QLBackground)
+    assert isinstance(ql_bkg, QLBackground)
+    assert ql_bkg.quantity('4-10 keV').unit == u.ct / (u.s * u.keV)
 
 
 @pytest.mark.remote_data
 def test_qlvariance():
-    ql_lc = TimeSeries(
+    ql_var = TimeSeries(
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-variance_20200506_V02.fits"
     )
-    assert isinstance(ql_lc, QLVariance)
+    assert isinstance(ql_var, QLVariance)
+    assert ql_var.quantity('4-20 keV').unit == u.ct / (u.s * u.keV)
 
 
 @pytest.mark.remote_data

--- a/stixpy/timeseries/tests/test_quicklook.py
+++ b/stixpy/timeseries/tests/test_quicklook.py
@@ -6,30 +6,64 @@ from stixpy.timeseries.quicklook import HKMaxi, QLBackground, QLLightCurve, QLVa
 
 
 @pytest.mark.remote_data
-def test_ql_lightcurve():
+@pytest.fixture()
+def ql_lightcurve():
     ql_lc = TimeSeries(
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-lightcurve_20200506_V02.fits"
     )
-    assert isinstance(ql_lc, QLLightCurve)
-    assert ql_lc.quantity('4-10 keV').unit == u.ct/(u.s * u.keV)
-
+    return ql_lc
 
 @pytest.mark.remote_data
-def test_qlbackground():
+@pytest.fixture()
+def ql_background():
     ql_bkg = TimeSeries(
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-background_20200506_V02.fits"
     )
-    assert isinstance(ql_bkg, QLBackground)
-    assert ql_bkg.quantity('4-10 keV').unit == u.ct / (u.s * u.keV)
-
+    return ql_bkg
 
 @pytest.mark.remote_data
-def test_qlvariance():
+@pytest.fixture()
+def ql_variance():
     ql_var = TimeSeries(
         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-variance_20200506_V02.fits"
     )
-    assert isinstance(ql_var, QLVariance)
-    assert ql_var.quantity('4-20 keV').unit == u.ct / (u.s * u.keV)
+    return ql_var
+
+@pytest.mark.remote_data
+def test_ql_lightcurve(ql_lightcurve):
+    assert isinstance(ql_lightcurve, QLLightCurve)
+    assert ql_lightcurve.quantity('4-10 keV').unit == u.ct/(u.s * u.keV)
+
+@pytest.mark.remote_data
+def test_ql_lightcurve_plot(ql_lightcurve):
+    ql_lightcurve.plot()
+    ql_lightcurve.plot(columns=['4-10 keV'])
+
+
+@pytest.mark.remote_data
+def test_ql_background(ql_background):
+    assert isinstance(ql_background, QLBackground)
+    assert ql_background.quantity('4-10 keV').unit == u.ct / (u.s * u.keV)
+
+
+@pytest.mark.remote_data
+def test_ql_background_plot(ql_background):
+    ql_background.plot()
+    ql_background.plot(columns=['4-10 keV'])
+
+
+
+@pytest.mark.remote_data
+def test_qlvariance(ql_variance):
+    assert isinstance(ql_variance, QLVariance)
+    assert ql_variance.quantity('4-20 keV').unit == u.ct / (u.s * u.keV)
+
+
+@pytest.mark.remote_data
+def test_qlvariance_plot(ql_variance):
+    ql_variance.plot()
+    ql_variance.plot(columns=['4-20 keV'])
+
 
 
 @pytest.mark.remote_data

--- a/stixpy/timeseries/tests/test_quicklook.py
+++ b/stixpy/timeseries/tests/test_quicklook.py
@@ -32,13 +32,13 @@ def ql_variance():
     return ql_var
 
 
-@pytest.mark.remote_data
-@pytest.fixture()
-def hk_maxi():
-    hk_maxi = TimeSeries(
-        r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/HK/solo_L1_stix-hk-maxi_20200506_V02U.fits"
-    )
-    return hk_maxi
+# @pytest.mark.remote_data
+# @pytest.fixture()
+# def hk_maxi():
+#     hk_maxi = TimeSeries(
+#         r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/HK/solo_L1_stix-hk-maxi_20200506_V02U.fits"
+#     )
+#     return hk_maxi
 
 
 @pytest.mark.remote_data
@@ -78,12 +78,15 @@ def test_ql_variance_plot(ql_variance):
 
 
 @pytest.mark.remote_data
-def test_hk_maxi(hk_maxi):
+def test_hk_maxi():
+    hk_maxi = TimeSeries(
+         "https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/HK/solo_L1_stix-hk-maxi_20200506_V02U.fits"
+     )
     assert isinstance(hk_maxi, HKMaxi)
     assert hk_maxi.quantity('hk_att_c').unit == u.mA
 
 
-@pytest.mark.remote_data
-def test_hk_maxi_plot(hk_maxi):
-    hk_maxi.plot()
-    hk_maxi.plot(columns=['hk_asp_photoa0_v'])
+# @pytest.mark.remote_data
+# def test_hk_maxi_plot(hk_maxi):
+#     hk_maxi.plot()
+#     hk_maxi.plot(columns=['hk_asp_photoa0_v'])


### PR DESCRIPTION
* Fix units so those in plots match the units in data
* Fix bug data units did not match the actual data units
   * Data had ct s-1 keV-1 but was really ct keV-1 now data is really in ct s-1 keV-1 
* Reconstruct the QTables from the HDU header pair so get units from headers
* Update livetime correction to use same function as imaging with the new parameter values
* Update plot code to use more of sunpy TimeSeries functions
* Add columns keyword with useful defaults
* Update tests to check for correct quantities

Closes #104

```
from matplotlib import pyplot as plt
from sunpy.timeseries import TimeSeries
from stixpy.timeseries.quicklook import HKMaxi, QLBackground, QLLightCurve, QLVariance

ql_lc = TimeSeries(r"https://pub099.cs.technik.fhnw.ch/fits/L1/2020/05/06/QL/solo_L1_stix-ql-lightcurve_20200506_V02.fits")
ql_lc.quantity('4-10 keV').unit
# Unit("ct / (keV s)")

ql_lc.plot()
plt.show()
```
![stix_ql_example](https://github.com/TCDSolar/stixpy/assets/24570854/cd2c8631-6403-4386-a434-76b80cdf7d2c)

