### PR TITLE
Some plotting fixes to science plotting

### DIFF
--- a/changelog/134.bugfix.rst
+++ b/changelog/134.bugfix.rst
@@ -1,0 +1,1 @@
+Fix some inconsistencies on the data units in plots, also return handle to the image from `~stixpy.product.sources.science.SpectrogramPlotMixin.plot_spectrogram`.

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -210,8 +210,8 @@ class SpectrogramPlotMixin:
         counts, errors, times, timedeltas, energies = self.get_data(
             detector_indices=did, pixel_indices=pid, time_indices=time_indices, energy_indices=energy_indices
         )
-        counts = counts.to(u.ct / u.s / u.keV).unit
-        errors = errors.to(u.ct / u.s / u.keV).unit
+        counts = counts.to(u.ct / u.s / u.keV)
+        errors = errors.to(u.ct / u.s / u.keV)
         timedeltas = timedeltas.to(u.s)
 
         e_edges = np.hstack([energies["e_low"], energies["e_high"][-1]])
@@ -310,8 +310,8 @@ class TimesSeriesPlotMixin:
             time_indices=time_indices,
             energy_indices=energy_indices,
         )
-        counts = counts.to(u.ct / u.s / u.keV).unit
-        errors = errors.to(u.ct / u.s / u.keV).unit
+        counts = counts.to(u.ct / u.s / u.keV)
+        errors = errors.to(u.ct / u.s / u.keV)
         timedeltas = timedeltas.to(u.s)
 
         labels = [f"{el.value} - {eh.value} keV" for el, eh in energies["e_low", "e_high"]]

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -210,6 +210,9 @@ class SpectrogramPlotMixin:
         counts, errors, times, timedeltas, energies = self.get_data(
             detector_indices=did, pixel_indices=pid, time_indices=time_indices, energy_indices=energy_indices
         )
+        counts = counts.to(u.ct / u.s / u.keV).unit
+        errors = errors.to(u.ct / u.s / u.keV).unit
+        timedeltas = timedeltas.to(u.s)
 
         e_edges = np.hstack([energies["e_low"], energies["e_high"][-1]])
         t_edges = Time(
@@ -307,8 +310,11 @@ class TimesSeriesPlotMixin:
             time_indices=time_indices,
             energy_indices=energy_indices,
         )
+        counts = counts.to(u.ct / u.s / u.keV).unit
+        errors = errors.to(u.ct / u.s / u.keV).unit
+        timedeltas = timedeltas.to(u.s)
 
-        labels = [f"{el.value} - {eh.value}" for el, eh in energies["e_low", "e_high"]]
+        labels = [f"{el.value} - {eh.value} keV" for el, eh in energies["e_low", "e_high"]]
 
         n_time, n_det, n_pix, n_energy = counts.shape
 
@@ -366,6 +372,10 @@ class PixelPlotMixin:
             fig, axes = plt.subplots(nrows=4, ncols=8, sharex=True, sharey=True, figsize=(10, 5))
 
         counts, count_err, times, dt, energies = self.get_data(time_indices=time_indices, energy_indices=energy_indices)
+
+        counts = counts.to(u.ct / u.s / u.keV).unit
+        count_err = count_err.to(u.ct / u.s / u.keV).unit
+        dt = dt.to(u.s)
 
         def timeval(val):
             return times[val].isot

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -214,7 +214,7 @@ class SpectrogramPlotMixin:
         errors = errors.to(u.ct / u.s / u.keV)
         timedeltas = timedeltas.to(u.s)
 
-        e_edges = np.hstack([energies["e_low"], energies["e_high"][-1]])
+        e_edges = np.hstack([energies["e_low"], energies["e_high"][-1]]).value
         t_edges = Time(
             np.concatenate([times - timedeltas.reshape(-1) / 2, times[-1] + timedeltas.reshape(-1)[-1:] / 2])
         )
@@ -226,7 +226,7 @@ class SpectrogramPlotMixin:
 
         pcolor_kwargs = {"norm": LogNorm(), "shading": "flat"}
         pcolor_kwargs.update(plot_kwargs)
-        im = axes.pcolormesh(t_edges.datetime, e_edges[1:-1], counts[:, 0, 0, 1:-1].T, **pcolor_kwargs)  # noqa
+        im = axes.pcolormesh(t_edges.datetime, e_edges[1:-1], counts[:, 0, 0, 1:-1].T.value, **pcolor_kwargs)  # noqa
 
         # axes.colorbar(im).set_label(format(counts.unit))
         axes.xaxis_date()

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -234,6 +234,10 @@ class SpectrogramPlotMixin:
         axes.xaxis.set_major_formatter(DateFormatter("%d %H:%M"))
         # fig.autofmt_xdate()
         # fig.tight_layout()
+        for i in plt.get_fignums():
+            if axes in plt.figure(i).axes:
+                plt.sca(axes)
+                plt.sci(im)
 
         return im
 

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -226,7 +226,7 @@ class SpectrogramPlotMixin:
 
         pcolor_kwargs = {"norm": LogNorm(), "shading": "flat"}
         pcolor_kwargs.update(plot_kwargs)
-        im = axes.pcolormesh(t_edges.datetime, e_edges[1:-1], counts[:, 0, 0, 1:-1].T.value, **pcolor_kwargs)  # noqa
+        im = axes.pcolormesh(t_edges.datetime, e_edges[1:-1], counts[:, 0, 0, 1:-1].T, **pcolor_kwargs)  # noqa
 
         # axes.colorbar(im).set_label(format(counts.unit))
         axes.xaxis_date()
@@ -373,8 +373,8 @@ class PixelPlotMixin:
 
         counts, count_err, times, dt, energies = self.get_data(time_indices=time_indices, energy_indices=energy_indices)
 
-        counts = counts.to(u.ct / u.s / u.keV).unit
-        count_err = count_err.to(u.ct / u.s / u.keV).unit
+        counts = counts.to(u.ct / u.s / u.keV)
+        count_err = count_err.to(u.ct / u.s / u.keV)
         dt = dt.to(u.s)
 
         def timeval(val):

--- a/stixpy/product/sources/science.py
+++ b/stixpy/product/sources/science.py
@@ -235,7 +235,7 @@ class SpectrogramPlotMixin:
         # fig.autofmt_xdate()
         # fig.tight_layout()
 
-        return axes
+        return im
 
 
 class TimesSeriesPlotMixin:


### PR DESCRIPTION
This PR fixes:
- returns `im` rather than axes for `plot_spectrogram`, which allows user to then do `plt.colorbar` of `fig.add_colorbar(im)`
- fixes #129 
- fixes #130 