### PR TITLE
Bugfix grid transmission

### DIFF
--- a/changelog/146.bugfix.rst
+++ b/changelog/146.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in orientation of grids for internal shadowing.

--- a/stixpy/calibration/grid.py
+++ b/stixpy/calibration/grid.py
@@ -64,7 +64,7 @@ def _calculate_grid_transmission(grid_params, xy_flare_stix):
     -------
     Transmission through all grids defined by the grid parameters
     """
-    orient = 180 * u.deg - grid_params["o"] * u.deg  # As viewed from the detector side (data recorded from front)
+    orient = grid_params["o"] * u.deg  # As viewed from the detector side (data recorded from front)
     pitch = grid_params["p"]
     slit = grid_params["slit"]
     thick = grid_params["thick"]


### PR DESCRIPTION
> The grid orientation angle do not have to be "flipped" by 180 deg when we compute the offset angle of the flare location relative to the slats (in arcseconds). The grid orientation angles are indeed defined as in Figure 2 of The STIX Imaging Concept paper (Massa et al., 2023).