### PR TITLE
Fix typo in coordinate lookup for grid shadowing

### DIFF
--- a/changelog/156.bugfix.rst
+++ b/changelog/156.bugfix.rst
@@ -1,1 +1,1 @@
-Fix typo in `~stixpy.calibration.visibility.create_meta_pixels` which cased error if grid shadow correction was enabled
+Fix typo in `~stixpy.calibration.visibility.create_meta_pixels` which cased error if grid shadow correction was enabled. Also update grid calculations to use `Skycoord` objects.

--- a/changelog/156.bugfix.rst
+++ b/changelog/156.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typo in `~stixpy.calibration.visibility.create_meta_pixels` which cased error if grid shadow correction was enabled

--- a/stixpy/calibration/tests/test_grid.py
+++ b/stixpy/calibration/tests/test_grid.py
@@ -1,8 +1,10 @@
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.coordinates import SkyCoord
 
 from stixpy.calibration.grid import get_grid_transmission
+from stixpy.coordinates.frames import STIXImaging
 
 
 # Output values taken from IDL routine
@@ -10,7 +12,7 @@ from stixpy.calibration.grid import get_grid_transmission
     "input,out",
     [
         (
-            [0, 0] * u.arcsec,
+            SkyCoord(*[0, 0] * u.arcsec, frame=STIXImaging),
             [
                 [
                     0.38359416,
@@ -49,7 +51,7 @@ from stixpy.calibration.grid import get_grid_transmission
             ],
         ),
         (
-            [0, 500.0] * u.arcsec,
+            SkyCoord(*[0, 500.0] * u.arcsec, frame=STIXImaging),
             [
                 0.38119361,
                 0.23916472,

--- a/stixpy/calibration/tests/test_visibility.py
+++ b/stixpy/calibration/tests/test_visibility.py
@@ -137,6 +137,18 @@ def test_create_meta_pixels_timebins(flare_cpd):
     assert_quantity_allclose(np.sum(flare_cpd.duration[0:3]), meta_pixels["time_range"].dt.to(u.s))
 
 
+def test_create_meta_pixels_shadow(flare_cpd):
+    energy_range = [6, 12] * u.keV
+    time_range = [flare_cpd.times[0], flare_cpd.times[2]]
+    create_meta_pixels(
+        flare_cpd,
+        time_range=time_range,
+        energy_range=energy_range,
+        flare_location=STIXImaging(0 * u.arcsec, 0 * u.arcsec),
+        no_shadowing=False,
+    )
+
+
 @pytest.mark.parametrize(
     "pix_set, real_comp",
     [

--- a/stixpy/calibration/visibility.py
+++ b/stixpy/calibration/visibility.py
@@ -198,7 +198,7 @@ def create_meta_pixels(
         if not isinstance(flare_location, STIXImaging) and flare_location.obstime != time_range.center:
             roll, solo_heeq, stix_pointing = get_hpc_info(time_range.start, time_range.end)
             flare_location = flare_location.transform_to(STIXImaging(obstime=time_range.center, observer=solo_heeq))
-        grid_shadowing = get_grid_transmission(flare_location.xyz[::-1])
+        grid_shadowing = get_grid_transmission(flare_location)
         ct_summed = ct_summed / grid_shadowing.reshape(-1, 1) / 4  # transmission grid ~ 0.5*0.5 = .25
         ct_error_summed = ct_error_summed / grid_shadowing.reshape(-1, 1) / 4
 

--- a/stixpy/calibration/visibility.py
+++ b/stixpy/calibration/visibility.py
@@ -196,7 +196,7 @@ def create_meta_pixels(
 
     if not no_shadowing:
         if not isinstance(flare_location, STIXImaging) and flare_location.obstime != time_range.center:
-            roll, solo_heeq, stix_pointing = get_hpc_info(time_range.start, time_range.stop)
+            roll, solo_heeq, stix_pointing = get_hpc_info(time_range.start, time_range.end)
             flare_location = flare_location.transform_to(STIXImaging(obstime=time_range.center, observer=solo_heeq))
         grid_shadowing = get_grid_transmission(flare_location.xyz[::-1])
         ct_summed = ct_summed / grid_shadowing.reshape(-1, 1) / 4  # transmission grid ~ 0.5*0.5 = .25


### PR DESCRIPTION
This partially addresses #110 by fixing the typo in the coordinate info lookup used in the grid shadowing correction