### PR TITLE
Fix Fido client not finding data which contains midnight

### DIFF
--- a/changelog/176.bugfix.rst
+++ b/changelog/176.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug in STIX Fido client which caused data that spanned midnight to be missed.

--- a/stixpy/net/tests/test_client.py
+++ b/stixpy/net/tests/test_client.py
@@ -78,7 +78,7 @@ def http_response():
 @mock.patch(MOCK_PATH)
 def test_client(urlopen, client, http_response, time_range, nfiles):
     urlopen.return_value.read = mock.MagicMock()
-    urlopen.return_value.read.side_effect = [http_response] * 5
+    urlopen.return_value.read.side_effect = ["", http_response] * 5
     urlopen.close = mock.MagicMock(return_value=None)
     query = client.search(a.Time(*time_range), a.Instrument.stix, a.Level("L1"), a.stix.DataType.sci)
     assert len(query) == nfiles
@@ -239,10 +239,33 @@ def test_search_date_product_sci():
 @pytest.mark.remote_data
 def test_fido():
     res = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix)
-    assert len(res["stix"]) == 64
+    len_total = len(res["stix"])
+    assert len_total == 67
 
     res_ql = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix, a.stix.DataType.ql)
-    assert len(res_ql["stix"]) == 6
+    len_ql = len(res_ql["stix"])
+    assert len_ql == 6
 
     res_sci = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix, a.stix.DataType.sci)
-    assert len(res_sci["stix"]) == 55
+    len_sci = len(res_sci["stix"])
+    assert len_sci == 58
+
+    res_hk = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix, a.stix.DataType.hk)
+    len_kh = len(res_hk["stix"])
+    assert len_kh == 1
+
+    res_asp = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix, a.stix.DataType.asp)
+    len_asp = len(res_asp["stix"])
+    assert len_asp == 1
+
+    res_cal = Fido.search(a.Time("2020-11-17T00:00", "2020-11-17T23:59"), a.Instrument.stix, a.stix.DataType.cal)
+    len_cal = len(res_cal["stix"])
+    assert len_cal == 1
+
+    assert len_ql + len_sci + len_kh + len_asp + len_cal == len_total
+
+
+@pytest.mark.remote_data
+def test_fido_file_crosses_date_boundary():
+    q = Fido.search(a.Time("2023-06-01T00:00", "2023-06-01T00:30"), a.Instrument.stix, a.stix.DataProduct.sci_xray_spec)
+    assert len(q["stix"]) == 2


### PR DESCRIPTION
Closes #168 by update the code to extend search window and hence paths searched by 6.5 hours before the requested start time. As due to the way the archive is populated requests are located in the directory structure base on their start time. While the TM could support request of ~19days - operationally don't make request larger than ~6 hours.

